### PR TITLE
Add WhatsApp webhook server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,20 @@ The demo provides:
 When the user answers an inbox update request with their current kilometres, the slider updates automatically. Previous updates are shown in the inbox and cannot be edited.
 
 Open `index.html` in a web browser to try the example.
+
+## Webhook Server for WhatsApp Business
+
+This repository also includes a simple Express server that can act as a webhook endpoint for the WhatsApp Business API.
+
+### Setup
+1. Install Node.js dependencies:
+   ```
+   npm install
+   ```
+2. Start the server with your chosen verify token:
+   ```
+   WHATSAPP_VERIFY_TOKEN=your_token npm start
+   ```
+3. Expose `http://localhost:3000` to the internet using a tunneling service such as ngrok so Meta can reach it over HTTPS. Use the public URL as the callback URL when configuring the webhook in the Meta Business dashboard.
+
+The server responds to the GET webhook verification request and logs incoming POST messages to the console.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "metadevwabaapi",
+  "version": "1.0.0",
+  "description": "Demo for WhatsApp Business API Webhook",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const app = express();
+const VERIFY_TOKEN = process.env.WHATSAPP_VERIFY_TOKEN || 'YOUR_VERIFY_TOKEN';
+
+app.use(bodyParser.json());
+
+app.get('/webhook', (req, res) => {
+  const mode = req.query['hub.mode'];
+  const token = req.query['hub.verify_token'];
+  const challenge = req.query['hub.challenge'];
+
+  if (mode && token && mode === 'subscribe' && token === VERIFY_TOKEN) {
+    return res.status(200).send(challenge);
+  }
+  return res.sendStatus(403);
+});
+
+app.post('/webhook', (req, res) => {
+  console.log('Received webhook:', JSON.stringify(req.body, null, 2));
+  res.sendStatus(200);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Webhook server is listening on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add a small Express server for receiving WhatsApp webhook events
- document how to run the webhook server

## Testing
- `node --version`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844b34ad110832e912b6c8f5c1bda62