### PR TITLE
Add lender API key management

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ This repository also includes a simple Express server that can act as a webhook 
 3. Expose `http://localhost:3000` to the internet using a tunneling service such as ngrok so Meta can reach it over HTTPS. Use the public URL as the callback URL when configuring the webhook in the Meta Business dashboard.
 
 The server responds to the GET webhook verification request and logs incoming POST messages to the console.
+
+### Lender API Key Management
+
+Two helper endpoints allow you to generate and retrieve API keys for bank
+lenders that want to integrate with the OpenAI assistant "Jen - Finance".
+
+* `POST /generate-api-key` – pass a JSON body with `lenderId` to generate a
+  persistent API key.
+* `GET /lender-api-key/:lenderId` – retrieve the previously generated key for a
+  lender.
+
+Generated keys are stored in `lender-keys.json` in the project root.

--- a/lenderKeys.js
+++ b/lenderKeys.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+const { randomBytes } = require('crypto');
+
+const KEY_FILE = path.join(__dirname, 'lender-keys.json');
+let keys = {};
+
+function loadKeys() {
+  if (fs.existsSync(KEY_FILE)) {
+    try {
+      keys = JSON.parse(fs.readFileSync(KEY_FILE));
+    } catch (err) {
+      keys = {};
+    }
+  }
+}
+
+function saveKeys() {
+  fs.writeFileSync(KEY_FILE, JSON.stringify(keys, null, 2));
+}
+
+function generateKey(lenderId) {
+  const key = randomBytes(32).toString('hex');
+  keys[lenderId] = key;
+  saveKeys();
+  return key;
+}
+
+function getKey(lenderId) {
+  return keys[lenderId];
+}
+
+loadKeys();
+
+module.exports = {
+  generateKey,
+  getKey
+};

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const { generateKey, getKey } = require('./lenderKeys');
 
 const app = express();
 const VERIFY_TOKEN = process.env.WHATSAPP_VERIFY_TOKEN || 'YOUR_VERIFY_TOKEN';
@@ -20,6 +21,24 @@ app.get('/webhook', (req, res) => {
 app.post('/webhook', (req, res) => {
   console.log('Received webhook:', JSON.stringify(req.body, null, 2));
   res.sendStatus(200);
+});
+
+app.post('/generate-api-key', (req, res) => {
+  const { lenderId } = req.body;
+  if (!lenderId) {
+    return res.status(400).json({ message: 'lenderId required' });
+  }
+  const key = generateKey(lenderId);
+  res.json({ lenderId, apiKey: key });
+});
+
+app.get('/lender-api-key/:lenderId', (req, res) => {
+  const { lenderId } = req.params;
+  const key = getKey(lenderId);
+  if (!key) {
+    return res.status(404).json({ message: 'Key not found' });
+  }
+  res.json({ lenderId, apiKey: key });
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- manage lender API keys with a small helper module
- expose `/generate-api-key` and `/lender-api-key/:lenderId` routes
- document the new endpoints in README

## Testing
- `npm install` *(fails: unable to access registry)*

------
https://chatgpt.com/codex/tasks/task_e_684e215bb3d4832e84d079e15d394589